### PR TITLE
Revert "Use stdlib to cast string to bool"

### DIFF
--- a/jobs/settings.py
+++ b/jobs/settings.py
@@ -1,12 +1,22 @@
 import os
 from datetime import timedelta
-from distutils.util import strtobool
+
+
+# Force to cast strings to bool
+def str2bool(value: str, default: bool = False) -> bool:
+    cleaned_value = value.lower().strip()
+    if cleaned_value in ['true', 't', '1', 'yes']:
+        return True
+    if cleaned_value in ['false', 'f', '0', 'no']:
+        return False
+    return default
+
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 SECRET_KEY = '@pzqp#x^+#(olu#wy(6=mi9&a8n+g&x#af#apn07@j=5oin=xb'
 
-DEBUG = strtobool(os.environ.get('APF_DEBUG', False))
+DEBUG = str2bool(os.environ.get('APF_DEBUG', 'False'))
 
 INSTALLED_APPS = [
     'django.contrib.admin',


### PR DESCRIPTION
Improves #43 by using `django-environ` deal with environment variables.

