### PR TITLE
Add django-environ to manage environment variables.

### DIFF
--- a/jobs/settings/base.py
+++ b/jobs/settings/base.py
@@ -7,11 +7,6 @@ env = environ.Env(
 )
 environ.Env.read_env()
 
-env = environ.Env(
-    DEBUG=(bool, False)
-)
-environ.Env.read_env()
-
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 SECRET_KEY = '@pzqp#x^+#(olu#wy(6=mi9&a8n+g&x#af#apn07@j=5oin=xb'

--- a/jobs/settings/base.py
+++ b/jobs/settings/base.py
@@ -1,12 +1,16 @@
 import os
 from datetime import timedelta
-from distutils.util import strtobool
+import environ
+
+env = environ.Env(
+    DEBUG=(bool, False)
+)
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 SECRET_KEY = '@pzqp#x^+#(olu#wy(6=mi9&a8n+g&x#af#apn07@j=5oin=xb'
 
-DEBUG = strtobool(os.environ.get('APF_DEBUG', 'False'))
+DEBUG = env('DEBUG')
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/jobs/settings/base.py
+++ b/jobs/settings/base.py
@@ -5,6 +5,7 @@ import environ
 env = environ.Env(
     DEBUG=(bool, False)
 )
+environ.Env.read_env()
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ coreschema==0.0.4
 Django==3.0.7
 django-cors-headers==3.2.1
 django-elasticsearch-dsl==7.1.1
+django-environ==0.4.5
 djangorestframework==3.11.0
 djangorestframework-simplejwt==4.4.0
 drf-yasg==1.17.1


### PR DESCRIPTION
This PR improves #43 by using `django-environ` to deal with environment variables.