### PR TITLE
Use python slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8-slim-buster
 LABEL maintainer="GeeksCAT<info@geekscat.org>"
 
 WORKDIR /anem-per-feina/


### PR DESCRIPTION
## Change to python slim image

Just a little change on python image to improve size.
With python-3.8 the docker image size is 938MB, and with python-3.8-slim-buster decrease to 168MB.
