### PR TITLE
Fix development settings and clean import

### DIFF
--- a/jobs/settings/development.py
+++ b/jobs/settings/development.py
@@ -1,4 +1,4 @@
-from .base import *  # noqa
+from . import *  # noqa
 
 LOGGING = {
     "version": 1,

--- a/jobs/settings/testing.py
+++ b/jobs/settings/testing.py
@@ -1,1 +1,1 @@
-from .__init__ import *
+from . import *  #noqa


### PR DESCRIPTION
## Description
Fix the settings, when you try to run the dockerfile it doesn't work because the import `.base` doesn't exist.

Please provide enough information so that others can review your pull request:
The import in development settings was wrong. I added a #noqa to avoid flake8 warnings.

## Code formating

The code has to be well formatted following the formatting rules. For example in Python the code has to follow the PEP8.

Before create your PR, please make sure your code is formatted running:
```bash
$ >> black --exclude=venv,__pycache__ ./
```