### PR TITLE
Mute mypy errors for "check-code" CI

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Run source code analysis and code format
         run: |
           pre-commit run --all
-      - name: Run checks
+      - name: Run typing tests //will not raise
+        continue-on-error: true
         run: |
           python checks.py --since origin/master --typing


### PR DESCRIPTION
## Description

Related to #83, it ensures that "Run typing tests" step does not raises and continues without breaking the validation.

This will simplify the validation of other PRs (at least for code formatting).

The analysis will be performed to be able to review issues and solve it in parallel.

Once #83 will be solved we should reactivate the step (erasing the `continue-on-error` directive)

This will avoid this errors:
![image](https://user-images.githubusercontent.com/8709244/95980068-e93e9d00-0e1c-11eb-9d43-414c932ea016.png)


## Code formating

The code has to be well formatted following the formatting rules. For example in Python the code has to follow the PEP8.

Before create your PR, please make sure your code is formatted running:
```bash
$ >> black --exclude=venv,__pycache__ ./
```