### PR TITLE
Disable on pull_request due build errors

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: greetings-on-1st-interaction
 
-on: [pull_request, issues]
+on: [issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
## Description

Currently this action is raising at build time.

I propose to temporally disable it, at least for PR. If not PR tests will not be accomplished...

## Code formating

The code has to be well formatted following the formatting rules. For example in Python the code has to follow the PEP8.

Before create your PR, please make sure your code is well formatted and styled doing:
```bash
$ >> pre-commit run --all
```