### PR TITLE
Adding celery integration in sentry and add False as default

### DIFF
--- a/jobs/settings.py
+++ b/jobs/settings.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 
 import environ
 import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 
 env = environ.Env()
@@ -234,5 +235,10 @@ CONSTANCE_CONFIG_FIELDSETS = {
 }
 
 # Sentry
-SENTRY_URL = env("SENTRY_URL")
-sentry_sdk.init(dsn=SENTRY_URL, integrations=[DjangoIntegration()], send_default_pii=True)
+SENTRY_URL = env("SENTRY_URL", default=False)
+if SENTRY_URL:
+    sentry_sdk.init(
+        dsn=SENTRY_URL,
+        integrations=[DjangoIntegration(), CeleryIntegration()],
+        send_default_pii=True,
+    )


### PR DESCRIPTION
## Description
I added celery integration.
Also I set a default to False because we are using the same settings for development and also for testing where we don't have sentry and we don't need sentry there. Then I think it's better to have it as False by default and add the URL where we really need, like in production

## Code formating

The code has to be well formatted following the formatting rules. For example in Python the code has to follow the PEP8.

Before create your PR, please make sure your code is well formatted and styled doing:
```bash
$ >> pre-commit run --all
```