### PR TITLE
Username attribute reverted

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -13,7 +13,7 @@ GENDER_CHOICES = (("male", "Male"), ("female", "Female"))
 
 
 class User(AbstractUser):
-    username = models.CharField(max_length=64, default=None)
+    username = None
     role = models.CharField(
         max_length=12,
         error_messages={"required": "Role must be provided"},


### PR DESCRIPTION
## Description

We revert the `username` attribute for keep the original behaviour and prevent missing migration issue.

## Code formating

The code has to be well formatted following the formatting rules. For example in Python the code has to follow the PEP8.

Before create your PR, please make sure your code is well formatted and styled doing:
```bash
$ >> pre-commit run --all
```