### PR TITLE
Disable git ignoring for .mo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,7 @@ coverage.xml
 .pytest_cache/
 
 # Translations
-*.mo
+# *.mo  # disabled to avoid issues with weblate automatic workflows
 
 # Django stuff:
 


### PR DESCRIPTION
## Description

It avoids to ignore .mo files, needed to ensure normal Weblate workflows