### PR TITLE
Add formspree.io service for contact form

### DIFF
--- a/jobs/settings.py
+++ b/jobs/settings.py
@@ -313,6 +313,7 @@ NOTIFICATIONS_ASYNC_QUEUE_NAME = CELERY_LOW_QUEUE_NAME
 EMAIL_BACKEND = env("EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend")
 EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", default=False)
 EMAIL_USE_SSL = env.bool("EMAIL_USE_SSL", default=False)
+BASE_EMAIL = env("BASE_EMAIL", default="info@geekscat.org")
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="noreply@nemperfeina.cat")
 EMAIL_HOST = env("EMAIL_HOST", default=None)
 EMAIL_PORT = env("EMAIL_PORT", default=None)

--- a/jobsapp/templates/contact_us.html
+++ b/jobsapp/templates/contact_us.html
@@ -7,24 +7,19 @@ Contact us
 
 {% block content %}
 <div class="container mt-5 mb-5">
-<form action="" method="post">
-  {% csrf_token %} {% for field in form %}
-  <div class="form-group">
-    <label for="id_{{ field.name }}">{% trans field.label %}</label>
-    <input
-      type="{{ field.field.widget.input_type }}"
-      class="form-control"
-      name="{{ field.name }}"
-      id="id_{{ field.name }}"
-      placeholder="{{ field.field.widget.attrs.placeholder }}"
-    />
-  </div>
-  {% endfor %}
-  <div class="text-center">
+  <form action="https://formspree.io/f/xqkgbqek" method="POST">
+    {% csrf_token %} {% for field in form %}
+    <div class="form-group">
+      <label for="id_{{ field.name }}">{% trans field.label %}</label>
+      <input type="{{ field.field.widget.input_type }}" class="form-control" name="{{ field.name }}"
+        id="id_{{ field.name }}" placeholder="{{ field.field.widget.attrs.placeholder }}" />
+    </div>
+    {% endfor %}
+    <div class="text-center">
       <button type="submit" class="btn btn-outline-white-primary">
-      <i class="fa fa-send"></i> {% trans "Send message" %}
-    </button>
-  </div>
-</form>
+        <i class="fa fa-send"></i> {% trans "Send message" %}
+      </button>
+    </div>
+  </form>
 </div>
 {% endblock %}

--- a/jobsapp/templates/contact_us.html
+++ b/jobsapp/templates/contact_us.html
@@ -12,7 +12,7 @@ Contact us
     <div class="form-group">
       <label for="id_{{ field.name }}">{% trans field.label %}</label>
       <input type="{{ field.field.widget.input_type }}" class="form-control" name="{{ field.name }}"
-        id="id_{{ field.name }}" placeholder="{{ field.field.widget.attrs.placeholder }}" />
+        id="id_{{ field.name }}" placeholder="{{ field.field.widget.attrs.placeholder }}" required>
     </div>
     {% endfor %}
     <div class="text-center">

--- a/jobsapp/utils.py
+++ b/jobsapp/utils.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from jobs.settings import EMAIL_HOST
+from jobs.settings import BASE_EMAIL
 from jobsapp.tasks import _send_email
 
 
@@ -19,7 +19,7 @@ def contact_us_email(data: Dict[str, Any]) -> None:
             "message": message,
             "from_email": data.get("from_email"),
             "recipient_list": [
-                EMAIL_HOST,
+                BASE_EMAIL,
             ],
         }
     )

--- a/manifests/env.yaml
+++ b/manifests/env.yaml
@@ -25,3 +25,4 @@ data:
   DEFAULT_FROM_EMAIL: "noreply@nemperfeina.cat"
   EMAIL_HOST: "localhost"
   EMAIL_PORT: "587"
+

--- a/manifests/env.yaml
+++ b/manifests/env.yaml
@@ -25,4 +25,4 @@ data:
   DEFAULT_FROM_EMAIL: "noreply@nemperfeina.cat"
   EMAIL_HOST: "localhost"
   EMAIL_PORT: "587"
-
+  BASE_EMAIL: "it@geekscat.org"


### PR DESCRIPTION
Contact form service now is provided by https://formspree.io.

Also it fixes SMTP delivery.

Changes introduced in #133

It also integrates some other interesting EMAIL related fields like
- `BASE_EMAIL`: to define base destination email
