### PR TITLE
Fix contributing.md error in pip install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ git checkout common/master -b <your_branch_name>
   pre-commit run --all
   ```
 
-> **Tip:** Ensure you have `pre-commit` tool installed by doing `python -m pip -r requirements-test.txt` inside you virtual environment. (Optional) Doing `pre-commit install` in your local repo will ensure that `pre-commit run --all` command runs automatically on every commit.
+> **Tip:** Ensure you have `pre-commit` tool installed by doing `python -m pip install -r requirements-test.txt` inside you virtual environment. (Optional) Doing `pre-commit install` in your local repo will ensure that `pre-commit run --all` command runs automatically on every commit.
 > **Note:** If there is any error or warning, please solve it before continue.
 
 9.  Push the committed changes to your fork (the `origin` remote)


### PR DESCRIPTION
## Description

I have encountered and error while following the CONTRIBUTING.md file. In the part of install the requirements it miss the `install` word in the command.