### PR TITLE
Remove the Github social auth button

### DIFF
--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -44,12 +44,14 @@
             <em class="fa fa-sign-in"></em>
             {% trans "Log in" %}
           </button>
+          <!--
           <div class="btn btn-outline-white-primary" style="border-color:black">
             <a href="{% url "social:begin" "github" %}" style="color:black">
               <em class="fa fa-github-square"></em>
               {% trans "Login with Github" %}
             </a>
           </div>
+          -->
         </div>
       </form>
     </div>

--- a/accounts/templates/accounts/login.html
+++ b/accounts/templates/accounts/login.html
@@ -44,14 +44,14 @@
             <em class="fa fa-sign-in"></em>
             {% trans "Log in" %}
           </button>
-          <!--
+          {% comment %}
           <div class="btn btn-outline-white-primary" style="border-color:black">
             <a href="{% url "social:begin" "github" %}" style="color:black">
               <em class="fa fa-github-square"></em>
               {% trans "Login with Github" %}
             </a>
           </div>
-          -->
+          {% endcomment %}
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Description

Fix #165 

This PR removes the github social auth button. This is the first step, but in the future we should check the real issue and fix it